### PR TITLE
Create new config values

### DIFF
--- a/Controller/GluggiController.php
+++ b/Controller/GluggiController.php
@@ -127,7 +127,7 @@ class GluggiController extends AbstractController
      * @return Response
      * @throws \Becklyn\AssetsBundle\Exception\AssetsException
      */
-    public function layoutAssets (GluggiConfig $config, AssetHtmlGenerator $htmlGenerator, string $type, array $addAssets, array $overrideAssets) : Response
+    public function layoutAssets (GluggiConfig $config, AssetHtmlGenerator $htmlGenerator, string $type, array $addAssets = [], array $overrideAssets = []) : Response
     {
         $overrideAssets = $overrideAssets[$type] ?? [];
 

--- a/Controller/GluggiController.php
+++ b/Controller/GluggiController.php
@@ -129,30 +129,34 @@ class GluggiController extends AbstractController
      */
     public function layoutAssets (GluggiConfig $config, AssetHtmlGenerator $htmlGenerator, string $type, array $addAssets, array $overrideAssets) : Response
     {
-        switch ($type)
-        {
-            case "js_head":
-                $assetPaths = $config->getJavaScriptHeadFiles();
-                break;
-
-            case "js":
-                $assetPaths = $config->getJavaScriptFiles();
-                break;
-
-            case "css":
-                $assetPaths = $config->getCssFiles();
-                break;
-
-            default:
-                $assetPaths = [];
-                break;
-        }
-
-        $assetPaths = \array_merge($assetPaths, $addAssets);
+        $overrideAssets = $overrideAssets[$type] ?? [];
 
         if (!empty($overrideAssets))
         {
             $assetPaths = $overrideAssets;
+        }
+        else
+        {
+            switch ($type)
+            {
+                case "js_head":
+                    $assetPaths = $config->getJavaScriptHeadFiles();
+                    break;
+
+                case "js":
+                    $assetPaths = $config->getJavaScriptFiles();
+                    break;
+
+                case "css":
+                    $assetPaths = $config->getCssFiles();
+                    break;
+
+                default:
+                    $assetPaths = [];
+                    break;
+            }
+
+            $assetPaths = \array_merge($assetPaths, $addAssets[$type] ?? null);
         }
 
         return new Response(

--- a/Controller/GluggiController.php
+++ b/Controller/GluggiController.php
@@ -156,7 +156,7 @@ class GluggiController extends AbstractController
                     break;
             }
 
-            $assetPaths = \array_merge($assetPaths, $addAssets[$type] ?? null);
+            $assetPaths = \array_merge($assetPaths, $addAssets[$type] ?? []);
         }
 
         return new Response(

--- a/Controller/GluggiController.php
+++ b/Controller/GluggiController.php
@@ -121,10 +121,13 @@ class GluggiController extends AbstractController
      * @param GluggiConfig       $config
      * @param AssetHtmlGenerator $htmlGenerator
      * @param string             $type
+     * @param array              $addAssets
+     * @param array              $overrideAssets
+     *
      * @return Response
      * @throws \Becklyn\AssetsBundle\Exception\AssetsException
      */
-    public function layoutAssets (GluggiConfig $config, AssetHtmlGenerator $htmlGenerator, string $type) : Response
+    public function layoutAssets (GluggiConfig $config, AssetHtmlGenerator $htmlGenerator, string $type, array $addAssets, array $overrideAssets) : Response
     {
         switch ($type)
         {
@@ -143,6 +146,13 @@ class GluggiController extends AbstractController
             default:
                 $assetPaths = [];
                 break;
+        }
+
+        $assetPaths = \array_merge($assetPaths, $addAssets);
+
+        if (!empty($overrideAssets))
+        {
+            $assetPaths = $overrideAssets;
         }
 
         return new Response(

--- a/README.md
+++ b/README.md
@@ -250,12 +250,26 @@ The configuration format is YAML. All configuration parameters are optional.
 #### Defined configuration parameters
 
 
-| Parameter      | type     | in                    | description                                          |
-| -------------- | -------- | --------------------- | ---------------------------------------------------- |
-| `body_class`   | `string` | (*any isolated view*) | Sets the given class on the body.                    |
-| `prevent_zoom` | `bool`   | (*any isolated view*) | Sets the `viewport` meta tag to prevent mobile zoom. |
+| Parameter         | type     | in                    | description                                          |
+| ----------------- | -------- | --------------------- | ---------------------------------------------------- |
+| `body_class`      | `string` | (*any isolated view*) | Sets the given class on the body.                    |
+| `prevent_zoom`    | `bool`   | (*any isolated view*) | Sets the `viewport` meta tag to prevent mobile zoom. |
+| `add_assets`      | `array`  | (*any isolated view*) | Adds given assets to a component.                    |
+| `override_assets` | `array`  | (*any isolated view*) | Overrides the given assets on a component.           |
 
-
+##### Define configuration parameters "add_assets" and "override_assets"
+The configuration parameters `add_assets` and `override_assets` are defined similar to the default configuration.
+```yaml
+override_assets:
+    css: []
+    js: []
+    js_head: []
+    
+add_assets:
+    css: []
+    js: []
+    js_head: []
+```
 
 ### Index Info
 

--- a/README.md
+++ b/README.md
@@ -257,8 +257,11 @@ The configuration format is YAML. All configuration parameters are optional.
 | `add_assets`      | `array`  | (*any isolated view*) | Adds given assets to a component.                    |
 | `override_assets` | `array`  | (*any isolated view*) | Overrides the given assets on a component.           |
 
+
 ##### Define configuration parameters "add_assets" and "override_assets"
+
 The configuration parameters `add_assets` and `override_assets` are defined similar to the default configuration.
+
 ```yaml
 override_assets:
     css: []

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -12,11 +12,51 @@
         {% endblock %}
 
         {% block stylesheets %}
-            {{ render(controller('Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets', {type: "css"})) }}
+            {%- if templateConfiguration.override_assets.css is defined -%}
+                {%- if templateConfiguration.override_assets.css is iterable -%}
+                    {% for css_file in templateConfiguration.override_assets.css %}
+                        <link rel="stylesheet" href="{{ asset(css_file) }}">
+                    {% endfor %}
+                {% else %}
+                    <link rel="stylesheet" href="{{ asset(templateConfiguration.override_assets.css) }}">
+                {%- endif -%}
+            {%- else -%}
+                {{ render(controller('Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets', {type: "css"})) }}
+
+                {%- if templateConfiguration.add_assets.css is defined -%}
+                    {%- if templateConfiguration.add_assets.css is iterable -%}
+                        {% for css_file in templateConfiguration.add_assets.css %}
+                            <link rel="stylesheet" href="{{ asset(css_file) }}">
+                        {% endfor %}
+                    {% else %}
+                        <link rel="stylesheet" href="{{ asset(templateConfiguration.add_assets.css) }}">
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endif -%}
         {% endblock %}
 
         {% block javascripts_head %}
-            {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js_head"})) }}
+            {%- if templateConfiguration.override_assets.js_head is defined -%}
+                {%- if templateConfiguration.override_assets.js_head is iterable -%}
+                    {% for js_head_file in templateConfiguration.override_assets.js_head %}
+                        <script type="text/javascript" src="{{ asset(js_head_file) }}"></script>
+                    {% endfor %}
+                {% else %}
+                    <script type="text/javascript" src="{{ asset(templateConfiguration.override_assets.js_head) }}"></script>
+                {%- endif -%}
+            {%- else -%}
+                {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js_head_head"})) }}
+
+                {%- if templateConfiguration.add_assets.js_head is defined -%}
+                    {%- if templateConfiguration.add_assets.js_head is iterable -%}
+                        {% for js_head_file in templateConfiguration.add_assets.js_head %}
+                            <script type="text/javascript" src="{{ asset(js_head_file) }}"></script>
+                        {% endfor %}
+                    {% else %}
+                        <script type="text/javascript" src="{{ asset(templateConfiguration.add_assets.js_head) }}"></script>
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endif -%}
         {% endblock %}
     </head>
     <body {% block body_attributes -%}
@@ -48,7 +88,27 @@
 
         {% endblock %}
         {% block javascripts %}
-            {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js"})) }}
+            {%- if templateConfiguration.override_assets.js is defined -%}
+                {%- if templateConfiguration.override_assets.js is iterable -%}
+                    {% for js_file in templateConfiguration.override_assets.js %}
+                        <script type="text/javascript" src="{{ asset(js_file) }}"></script>
+                    {% endfor %}
+                {% else %}
+                    <script type="text/javascript" src="{{ asset(templateConfiguration.override_assets.js) }}"></script>
+                {%- endif -%}
+            {%- else -%}
+                {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js"})) }}
+
+                {%- if templateConfiguration.add_assets.js is defined -%}
+                    {%- if templateConfiguration.add_assets.js is iterable -%}
+                        {% for js_file in templateConfiguration.add_assets.js %}
+                        <script type="text/javascript" src="{{ asset(js_file) }}"></script>
+                        {% endfor %}
+                    {% else %}
+                        <script type="text/javascript" src="{{ asset(templateConfiguration.add_assets.js) }}"></script>
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endif -%}
         {% endblock %}
     </body>
 </html>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -12,51 +12,19 @@
         {% endblock %}
 
         {% block stylesheets %}
-            {%- if templateConfiguration.override_assets.css is defined -%}
-                {%- if templateConfiguration.override_assets.css is iterable -%}
-                    {% for css_file in templateConfiguration.override_assets.css %}
-                        <link rel="stylesheet" href="{{ asset(css_file) }}">
-                    {% endfor %}
-                {% else %}
-                    <link rel="stylesheet" href="{{ asset(templateConfiguration.override_assets.css) }}">
-                {%- endif -%}
-            {%- else -%}
-                {{ render(controller('Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets', {type: "css"})) }}
-
-                {%- if templateConfiguration.add_assets.css is defined -%}
-                    {%- if templateConfiguration.add_assets.css is iterable -%}
-                        {% for css_file in templateConfiguration.add_assets.css %}
-                            <link rel="stylesheet" href="{{ asset(css_file) }}">
-                        {% endfor %}
-                    {% else %}
-                        <link rel="stylesheet" href="{{ asset(templateConfiguration.add_assets.css) }}">
-                    {%- endif -%}
-                {%- endif -%}
-            {%- endif -%}
+            {{ render(controller('Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets', {
+                type: "css",
+                addAssets: templateConfiguration.add_assets.css|default([]),
+                overrideAssets: templateConfiguration.override_assets.css|default([]),
+            })) }}
         {% endblock %}
 
         {% block javascripts_head %}
-            {%- if templateConfiguration.override_assets.js_head is defined -%}
-                {%- if templateConfiguration.override_assets.js_head is iterable -%}
-                    {% for js_head_file in templateConfiguration.override_assets.js_head %}
-                        <script type="text/javascript" src="{{ asset(js_head_file) }}"></script>
-                    {% endfor %}
-                {% else %}
-                    <script type="text/javascript" src="{{ asset(templateConfiguration.override_assets.js_head) }}"></script>
-                {%- endif -%}
-            {%- else -%}
-                {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js_head_head"})) }}
-
-                {%- if templateConfiguration.add_assets.js_head is defined -%}
-                    {%- if templateConfiguration.add_assets.js_head is iterable -%}
-                        {% for js_head_file in templateConfiguration.add_assets.js_head %}
-                            <script type="text/javascript" src="{{ asset(js_head_file) }}"></script>
-                        {% endfor %}
-                    {% else %}
-                        <script type="text/javascript" src="{{ asset(templateConfiguration.add_assets.js_head) }}"></script>
-                    {%- endif -%}
-                {%- endif -%}
-            {%- endif -%}
+            {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {
+                type: "js_head",
+                addAssets: templateConfiguration.add_assets.js_head|default([]),
+                overrideAssets: templateConfiguration.override_assets.js_head|default([]),
+            })) }}
         {% endblock %}
     </head>
     <body {% block body_attributes -%}
@@ -88,27 +56,11 @@
 
         {% endblock %}
         {% block javascripts %}
-            {%- if templateConfiguration.override_assets.js is defined -%}
-                {%- if templateConfiguration.override_assets.js is iterable -%}
-                    {% for js_file in templateConfiguration.override_assets.js %}
-                        <script type="text/javascript" src="{{ asset(js_file) }}"></script>
-                    {% endfor %}
-                {% else %}
-                    <script type="text/javascript" src="{{ asset(templateConfiguration.override_assets.js) }}"></script>
-                {%- endif -%}
-            {%- else -%}
-                {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {type: "js"})) }}
-
-                {%- if templateConfiguration.add_assets.js is defined -%}
-                    {%- if templateConfiguration.add_assets.js is iterable -%}
-                        {% for js_file in templateConfiguration.add_assets.js %}
-                        <script type="text/javascript" src="{{ asset(js_file) }}"></script>
-                        {% endfor %}
-                    {% else %}
-                        <script type="text/javascript" src="{{ asset(templateConfiguration.add_assets.js) }}"></script>
-                    {%- endif -%}
-                {%- endif -%}
-            {%- endif -%}
+            {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {
+                type: "js",
+                addAssets: templateConfiguration.add_assets.js|default([]),
+                overrideAssets: templateConfiguration.override_assets.js|default([]),
+            })) }}
         {% endblock %}
     </body>
 </html>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -14,16 +14,16 @@
         {% block stylesheets %}
             {{ render(controller('Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets', {
                 type: "css",
-                addAssets: templateConfiguration.add_assets.css|default([]),
-                overrideAssets: templateConfiguration.override_assets.css|default([]),
+                addAssets: templateConfiguration.add_assets ?? [],
+                overrideAssets: templateConfiguration.override_assets ?? [],
             })) }}
         {% endblock %}
 
         {% block javascripts_head %}
             {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {
                 type: "js_head",
-                addAssets: templateConfiguration.add_assets.js_head|default([]),
-                overrideAssets: templateConfiguration.override_assets.js_head|default([]),
+                addAssets: templateConfiguration.add_assets ?? [],
+                overrideAssets: templateConfiguration.override_assets ?? [],
             })) }}
         {% endblock %}
     </head>
@@ -55,11 +55,12 @@
             {% block content "" %}
 
         {% endblock %}
+
         {% block javascripts %}
             {{ render(controller("Becklyn\\GluggiBundle\\Controller\\GluggiController::layoutAssets", {
                 type: "js",
-                addAssets: templateConfiguration.add_assets.js|default([]),
-                overrideAssets: templateConfiguration.override_assets.js|default([]),
+                addAssets: templateConfiguration.add_assets ?? [],
+                overrideAssets: templateConfiguration.override_assets ?? [],
             })) }}
         {% endblock %}
     </body>


### PR DESCRIPTION
The possibility of overriding or adding assets on a single component would be nice, hence this pull request. It introduces the possibility of configuring it the same way as the default config, only on a component level.

```yaml
override_assets:
    css: []
    js: []
    js_head: []
    
add_assets:
    css: []
    js: []
    js_head: []
```