### PR TITLE
fix transitive dependency check on circular structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.2.1
+=====
+
+*   (bug) If a component references itself within a `standalone` check the dependency calculation does not longer fail. 
+
+
 3.2.0
 =====
 

--- a/src/Usages/DependenciesResolver.php
+++ b/src/Usages/DependenciesResolver.php
@@ -104,6 +104,8 @@ class DependenciesResolver
                 $result[$queueUse->getFullKey()] = $queueUse;
                 $queue[] = $queueUse;
             }
+
+            $alreadyChecked[$queueEntry->getFullKey()] = true;
         }
 
         return $result;


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | yes                                                              |
| New feature?  | no
| Improvement?  | no    |
| BC breaks?    | no                                                                |
| Deprecations? | no     |
| Docs PR       | -                                 |

If you have a component (`atom/component.html.twig`) that has code like this: 
```
{% if standalone %}
    {{ gluggi("atom", "component") }}
    {{ gluggi("atom", "component") }}
{% endif %}
```

And you use it in an other component, the calculation of the dependencies for that other component fails as it results in an endless loop.