### PR TITLE
Add `variants.html.twig` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.4.0
+=====
+
+*   (feature) Add `variants.html.twig` template for automatic rendering of all permutations of a component.
+
+
 3.3.0
 =====
 

--- a/src/Resources/views/component/variations.html.twig
+++ b/src/Resources/views/component/variations.html.twig
@@ -1,0 +1,51 @@
+{%- set standalone = standalone|default(false) -%}
+
+{%- if standalone -%}<div class="gluggi-variations">{%- endif -%}
+    {%- set _options = _options|default({}) -%}
+    {%- set permutations = {} -%}
+    {%- set chunckSize = 1 -%}
+    {%- set numberOfPermutations = 1 -%}
+
+    {%- if not standalone -%}
+        {%- set _options = {} -%}
+    {%- endif -%}
+
+    {%- for option, values in _options -%}
+        {%- set numberOfPermutations = numberOfPermutations * values|length -%}
+    {%- endfor -%}
+
+
+    {%- for i in 0..(numberOfPermutations - 1) -%}
+        {%- set permutations = permutations|merge({("i"~i) : []}) -%}
+    {%- endfor -%}
+
+
+    {%- for option, values in _options -%}
+        {%- set permutationIndex = 0 -%}
+
+        {%- for i in 0..(chunckSize - 1) -%}
+            {%- for value in values -%}
+                {%- for j in 0..((numberOfPermutations / values|length / chunckSize) - 1) -%}
+                    {%- set permutations = permutations|merge({("i"~permutationIndex): permutations["i"~permutationIndex]|merge([value])}) -%}
+                    {%- set permutationIndex = permutationIndex + 1 -%}
+                {%- endfor -%}
+            {%- endfor -%}
+        {%- endfor -%}
+
+        {%- set chunckSize = chunckSize * values|length -%}
+    {%- endfor -%}
+
+
+    {%- set optionKeys = _options|keys -%}
+    {%- for permutation in permutations -%}
+        {%- set variables = {} -%}
+        {%- for option, value in permutation -%}
+            {%- set variables = variables|merge({(optionKeys[option]) : value}) -%}
+        {%- endfor -%}
+
+        {%- with variables -%}
+            {%- block component "" -%}
+        {%- endwith -%}
+    {%- endfor -%}
+{%- if standalone -%}</div>{%- endif -%}
+


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      |no                                                                |
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| BC breaks?    |no                                                                |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |

Add `variants.html.twig` template for automatic rendering of all permutations of a component.
